### PR TITLE
Dashboard integers and timeseries point connection

### DIFF
--- a/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
@@ -559,7 +559,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": 60000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -690,7 +690,7 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"mc_1p0\" or  r[\"_field\"] == \"mc_2p5\" or  r[\"_field\"] == \"mc_4p0\" or  r[\"_field\"] == \"mc_10p0\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> keep(columns: [\"_field\",\"_value\",\"_time\"])",
+          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"mc_1p0\" or  r[\"_field\"] == \"mc_2p5\" or  r[\"_field\"] == \"mc_4p0\" or  r[\"_field\"] == \"mc_10p0\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: true)\n  |> keep(columns: [\"_field\",\"_value\",\"_time\"])",
           "refId": "A"
         }
       ],
@@ -728,7 +728,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": 60000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -783,7 +783,7 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"ambient_t\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"ambient_t\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: true)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -833,7 +833,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": 60000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -888,7 +888,7 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"ambient_rh\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"ambient_rh\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: true)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -939,7 +939,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": 60000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1015,7 +1015,7 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voc_index\" or r[\"_field\"] == \"nox_index\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> keep(columns: [\"_field\",\"_value\",\"_time\"])\n  ",
+          "query": "from(bucket: \"airparticle_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"air_particles\")\n  |> filter(fn: (r) => r[\"_field\"] == \"voc_index\" or r[\"_field\"] == \"nox_index\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: true)\n  |> keep(columns: [\"_field\",\"_value\",\"_time\"])\n  ",
           "refId": "A"
         }
       ],
@@ -1084,13 +1084,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Air Particle Dashboard",
   "uid": "q39y6tRgk1",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
@@ -381,7 +381,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 2,
+          "decimals": 0,
           "mappings": [],
           "max": 500,
           "min": 0,
@@ -460,7 +460,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 2,
+          "decimals": 0,
           "mappings": [],
           "max": 500,
           "min": 0,
@@ -1060,7 +1060,7 @@
     "list": [
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "Machine_1",
           "value": "Machine_1"
         },
@@ -1084,13 +1084,13 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Air Particle Dashboard",
   "uid": "q39y6tRgk1",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
@@ -1084,13 +1084,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Air Particle Dashboard",
   "uid": "q39y6tRgk1",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/AirParticleMonitoring/dashboard.json
@@ -1084,7 +1084,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
According to [the datasheet](https://www.farnell.com/datasheets/3689381.pdf), the VOC index is an integer between 1 and 500. In testing, although the MQTT JSON field is a float, it's always .0 

Here I've removed the 2 decimal places from it's Big Stat display. The same for NOx - although it's harder to get that to go up.

I've also made the graphs only join up points when they are close to each other in time (<1 minute). When stopping and starting the solution I saw large straight lines while the system was off for half an hour, which is not honest data.

