### PR TITLE
Hotfix/sample rate

### DIFF
--- a/particle_dc/code/measure.py
+++ b/particle_dc/code/measure.py
@@ -54,7 +54,6 @@ class AirParticleMeasureBuildingBlock(multiprocessing.Process):
         self.zmq_out = None
 
         self.collection_interval = config['sampling']['sample_interval']
-        self.sample_count = config['sampling']['sample_count']
         self.adc_module = config['adc']['adc_module']
 
     def do_connect(self):

--- a/particle_dc/config/config.toml
+++ b/particle_dc/config/config.toml
@@ -2,15 +2,11 @@
     machine="Machine_1"	#Name of the machine being monitored (can't have spaces)
 
 [adc]
-    # uncomment the adc that you are using (default is BCRobotics)
+    # uncomment the adc that you are using
     adc_module = "sen5x"
 
 [sampling]
-    sample_count = 5
-    sample_interval = 0.2
-
-[calculation]
-    
+    sample_interval = 1
 
 [computing]
 	hardware="Pi4"


### PR DESCRIPTION
Remove some unused clutter copied from Power Basic.

In order to achieve sampling at a sensible rate (such as 1Hz).

See also https://github.com/DigitalShoestringSolutions/AirParticleMonitoring/issues/10#issuecomment-2441911965