### PR TITLE
Discard old data before sampling and raise sampling errors

### DIFF
--- a/particle_dc/code/measure.py
+++ b/particle_dc/code/measure.py
@@ -90,13 +90,13 @@ class AirParticleMeasureBuildingBlock(multiprocessing.Process):
         while run:
             t += period
 
-            # Collect samples from ADC
+            # Collect sample from ADC
+            sample = None
             try:
                 sample = adc.sample()
-             #   sample_accumulator += sample
-              #  num_samples+=1
             except Exception as e:
                 logger.error(f"Sampling lead to exception{e} \\")
+                raise e
 
             # handle timestamps and timezones
             if time.time() > next_check:


### PR DESCRIPTION
I'm agreed that the proper fix for #13 is to replace the whole sensing module, but while that's not progressing with any pace here is a very simple patch. 

If sampling does raise an error, this will restart the docker container. To me that sounds like the correct behaviour. 